### PR TITLE
Upgrade flow-php/etl dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/flow-php/etl.git",
-                "reference": "894f1ba87b28f19c649b3ba3da98828fd9682657"
+                "reference": "4bfbf352e42aea37882e3bbbb55e1f1700bca348"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flow-php/etl/zipball/894f1ba87b28f19c649b3ba3da98828fd9682657",
-                "reference": "894f1ba87b28f19c649b3ba3da98828fd9682657",
+                "url": "https://api.github.com/repos/flow-php/etl/zipball/4bfbf352e42aea37882e3bbbb55e1f1700bca348",
+                "reference": "4bfbf352e42aea37882e3bbbb55e1f1700bca348",
                 "shasum": ""
             },
             "require": {
@@ -48,7 +48,7 @@
                 "issues": "https://github.com/flow-php/etl/issues",
                 "source": "https://github.com/flow-php/etl/tree/1.x"
             },
-            "time": "2021-04-18T14:28:38+00:00"
+            "time": "2021-06-14T09:44:06+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Flow/ETL/Row/Entry/JsonEntry.php
+++ b/src/Flow/ETL/Row/Entry/JsonEntry.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Entry;
 
-use Flow\ArrayComparison\ArrayWeakComparison;
+use Flow\ArrayComparison\ArrayComparison;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
 
@@ -87,6 +87,6 @@ final class JsonEntry implements Entry
 
     public function isEqual(Entry $entry) : bool
     {
-        return $this->is($entry->name()) && $entry instanceof self && (new ArrayWeakComparison())->equals($this->value, $entry->value);
+        return $this->is($entry->name()) && $entry instanceof self && (new ArrayComparison())->equals($this->value, $entry->value);
     }
 }

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/JsonEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/JsonEntryTest.php
@@ -105,11 +105,6 @@ final class JsonEntryTest extends TestCase
             new JsonEntry('name', [1, 2, 3]),
             new JsonEntry('name', [1, 2, 3]),
         ];
-        yield 'equal names and equal simple integerrish arrays with the same order' => [
-            true,
-            new JsonEntry('name', [1, 2, 3]),
-            new JsonEntry('name', ['1', '2', '3']),
-        ];
         yield 'equal names and equal simple integer arrays with different order' => [
             true,
             new JsonEntry('name', [1, 2, 3]),
@@ -134,6 +129,11 @@ final class JsonEntryTest extends TestCase
             true,
             new JsonEntry('name', ['foo' => 1, 'bar' => ['foo' => 'foo', 'bar' => 'bar'], 'baz']),
             new JsonEntry('name', ['baz', 'bar' => ['bar' => 'bar', 'foo' => 'foo'], 'foo' => 1]),
+        ];
+        yield 'equal names and equal simple integerrish arrays with the same order' => [
+            false,
+            new JsonEntry('name', [1, 2, 3]),
+            new JsonEntry('name', ['1', '2', '3']),
         ];
         yield 'equal names and equal multi dimensional array with missing entry' => [
             false,


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
<li>ArrayWeakComparison is not available anymore, we should use ArrayComparison</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

I was wondering why the test suite didn't fail, but it was executed before the merge of https://github.com/flow-php/etl/pull/54. I executed it now and it failed: https://github.com/flow-php/etl-adapter-json/runs/2818987011?check_suite_focus=true

This PR will fix it.