### PR TITLE
Unified JsonLoader behavior

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -121,12 +121,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/flow-php/etl.git",
-                "reference": "45780e12e2b7607ab39366eef1704fae005d03cd"
+                "reference": "c767f3c7c437781880ddedbe39f27c98aee11d27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flow-php/etl/zipball/45780e12e2b7607ab39366eef1704fae005d03cd",
-                "reference": "45780e12e2b7607ab39366eef1704fae005d03cd",
+                "url": "https://api.github.com/repos/flow-php/etl/zipball/c767f3c7c437781880ddedbe39f27c98aee11d27",
+                "reference": "c767f3c7c437781880ddedbe39f27c98aee11d27",
                 "shasum": ""
             },
             "require": {
@@ -139,7 +139,7 @@
                 "jawira/case-converter": "^3.4",
                 "laminas/laminas-hydrator": "^4.0",
                 "laravel/serializable-closure": "^1.1",
-                "symfony/validator": "^5.3"
+                "symfony/validator": "^5.3 || ^6.0"
             },
             "suggest": {
                 "jawira/case-converter": "Provides CaseConverter that is required by the EntryNameCaseConverterTransformer",
@@ -170,7 +170,7 @@
                 "issues": "https://github.com/flow-php/etl/issues",
                 "source": "https://github.com/flow-php/etl/tree/1.x"
             },
-            "time": "2022-04-10T10:14:58+00:00"
+            "time": "2022-05-20T09:48:10+00:00"
         },
         {
             "name": "ramsey/collection",
@@ -497,5 +497,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Flow/ETL/Adapter/JSON/JSONMachineExtractor.php
+++ b/src/Flow/ETL/Adapter/JSON/JSONMachineExtractor.php
@@ -16,7 +16,7 @@ final class JSONMachineExtractor implements Extractor
 {
     public function __construct(
         private readonly Items $jsonItems,
-        private readonly int $rowsInBatch,
+        private readonly int $rowsInBatch = 1000,
         private readonly string $rowEntryName = 'row'
     ) {
     }

--- a/tests/Flow/ETL/Tests/Integration/Adapter/JSON/JsonLoaderTest.php
+++ b/tests/Flow/ETL/Tests/Integration/Adapter/JSON/JsonLoaderTest.php
@@ -41,24 +41,45 @@ final class JsonLoaderTest extends TestCase
             )
         );
 
+        $loader->closure(new Rows());
+
         $this->assertJsonStringEqualsJsonString(
             <<<'JSON'
 [
-   [
-      {"id":0,"name":"name_0"},
-      {"id":1,"name":"name_1"},
-      {"id":2,"name":"name_2"},
-      {"id":3,"name":"name_3"},
-      {"id":4,"name":"name_4"},
-      {"id":5,"name":"name_5"}
-   ],
-   [
-      {"id":6,"name":"name_6"},
-      {"id":7,"name":"name_7"},
-      {"id":8,"name":"name_8"},
-      {"id":9,"name":"name_9"},
-      {"id":10,"name":"name_10"}
-   ]
+  {"id":0,"name":"name_0"},
+  {"id":1,"name":"name_1"},
+  {"id":2,"name":"name_2"},
+  {"id":3,"name":"name_3"},
+  {"id":4,"name":"name_4"},
+  {"id":5,"name":"name_5"},
+  {"id":6,"name":"name_6"},
+  {"id":7,"name":"name_7"},
+  {"id":8,"name":"name_8"},
+  {"id":9,"name":"name_9"},
+  {"id":10,"name":"name_10"}
+]
+JSON,
+            \file_get_contents($path)
+        );
+
+        if (\file_exists($path)) {
+            \unlink($path);
+        }
+    }
+
+    public function test_json_loader_loading_empty_string() : void
+    {
+        $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_etl_csv_loader', true) . '.json';
+
+        $loader = new JsonLoader($path);
+
+        $loader->load(new Rows());
+
+        $loader->closure(new Rows());
+
+        $this->assertJsonStringEqualsJsonString(
+            <<<'JSON'
+[
 ]
 JSON,
             \file_get_contents($path)
@@ -101,24 +122,22 @@ JSON,
 
         $files = \array_values(\array_diff(\scandir($path), ['..', '.']));
 
+        $loader->closure(new Rows());
+
         $this->assertJsonStringEqualsJsonString(
             <<<'JSON'
 [
-   [
       {"id":0,"name":"name_0"},
       {"id":1,"name":"name_1"},
       {"id":2,"name":"name_2"},
       {"id":3,"name":"name_3"},
       {"id":4,"name":"name_4"},
-      {"id":5,"name":"name_5"}
-   ],
-   [
+      {"id":5,"name":"name_5"},
       {"id":6,"name":"name_6"},
       {"id":7,"name":"name_7"},
       {"id":8,"name":"name_8"},
       {"id":9,"name":"name_9"},
       {"id":10,"name":"name_10"}
-   ]
 ]
 JSON,
             \file_get_contents($path . DIRECTORY_SEPARATOR . $files[0])


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Unified JsonLoader behavior</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This change allows to write and then read json without any additional transformations. 
Previously loader was doing something similar to:
```
[
     [rows...],
     [rows...],
]
```

Now it will do:
```
[
    rows,
    rows,
]
```